### PR TITLE
[WIP] Add mysqlclient instrumentor support for sqlcommenting

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
@@ -177,7 +177,7 @@ class MySQLClientInstrumentor(BaseInstrumentor):
             _CONNECTION_ATTRIBUTES,
             version=__version__,
             tracer_provider=tracer_provider,
-            enable_commenter=enable_sqlcommenter,
+            enable_commenter=enable_commenter,
             commenter_options=commenter_options,
         )
 

--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/src/opentelemetry/instrumentation/mysqlclient/__init__.py
@@ -36,6 +36,72 @@ Usage
     cursor.close()
     cnx.close()
 
+SQLCOMMENTER
+*****************************************
+You can optionally configure MySQLClient instrumentation to enable sqlcommenter which enriches
+the query with contextual information.
+
+.. code:: python
+
+    import MySQLdb
+    from opentelemetry.instrumentation.mysqlclient import MySQLClientInstrumentor
+
+
+    MySQLClientInstrumentor().instrument(enable_commenter=True, commenter_options={})
+
+    cnx = MySQLdb.connect(database="MySQL_Database")
+    cursor = cnx.cursor()
+    cursor.execute("INSERT INTO test (testField) VALUES (123)"
+    cnx.commit()
+    cursor.close()
+    cnx.close()
+
+For example,
+::
+
+   Invoking cursor.execute("INSERT INTO test (testField) VALUES (123)") will lead to sql query "INSERT INTO test (testField) VALUES (123)" but when SQLCommenter is enabled
+   the query will get appended with some configurable tags like "INSERT INTO test (testField) VALUES (123) /*tag=value*/;"
+
+SQLCommenter Configurations
+***************************
+We can configure the tags to be appended to the sqlquery log by adding configuration inside commenter_options(default:{}) keyword
+
+db_driver = True(Default) or False
+
+For example,
+::
+Enabling this flag will add MySQLdb and its version, e.g. /*MySQLdb%%3A1.2.3*/
+
+dbapi_threadsafety = True(Default) or False
+
+For example,
+::
+Enabling this flag will add threadsafety /*dbapi_threadsafety=2*/
+
+dbapi_level = True(Default) or False
+
+For example,
+::
+Enabling this flag will add dbapi_level /*dbapi_level='2.0'*/
+
+mysql_client_version = True(Default) or False
+
+For example,
+::
+Enabling this flag will add mysql_client_version /*mysql_client_version='123'*/
+
+driver_paramstyle = True(Default) or False
+
+For example,
+::
+Enabling this flag will add driver_paramstyle /*driver_paramstyle='pyformat'*/
+
+opentelemetry_values = True(Default) or False
+
+For example,
+::
+Enabling this flag will add traceparent values /*traceparent='00-03afa25236b8cd948fa853d67038ac79-405ff022e8247c46-01'*/
+
 API
 ---
 """
@@ -67,6 +133,8 @@ class MySQLClientInstrumentor(BaseInstrumentor):
         https://github.com/PyMySQL/mysqlclient/
         """
         tracer_provider = kwargs.get("tracer_provider")
+        enable_sqlcommenter = kwargs.get("enable_commenter", False)
+        commenter_options = kwargs.get("commenter_options", {})
 
         dbapi.wrap_connect(
             __name__,
@@ -76,6 +144,8 @@ class MySQLClientInstrumentor(BaseInstrumentor):
             _CONNECTION_ATTRIBUTES,
             version=__version__,
             tracer_provider=tracer_provider,
+            enable_commenter=enable_sqlcommenter,
+            commenter_options=commenter_options,
         )
 
     def _uninstrument(self, **kwargs):
@@ -83,7 +153,12 @@ class MySQLClientInstrumentor(BaseInstrumentor):
         dbapi.unwrap_connect(MySQLdb, "connect")
 
     @staticmethod
-    def instrument_connection(connection, tracer_provider=None):
+    def instrument_connection(
+        connection,
+        tracer_provider=None,
+        enable_commenter=None,
+        commenter_options=None,
+    ):
         """Enable instrumentation in a mysqlclient connection.
 
         Args:
@@ -102,6 +177,8 @@ class MySQLClientInstrumentor(BaseInstrumentor):
             _CONNECTION_ATTRIBUTES,
             version=__version__,
             tracer_provider=tracer_provider,
+            enable_commenter=enable_sqlcommenter,
+            commenter_options=commenter_options,
         )
 
     @staticmethod

--- a/instrumentation/opentelemetry-instrumentation-mysqlclient/tests/test_mysqlclient_integration.py
+++ b/instrumentation/opentelemetry-instrumentation-mysqlclient/tests/test_mysqlclient_integration.py
@@ -96,6 +96,42 @@ class TestMySQLClientIntegration(TestBase):
         spans_list = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans_list), 1)
 
+    @mock.patch("opentelemetry.instrumentation.dbapi.instrument_connection")
+    @mock.patch("MySQLdb.connect")
+    # pylint: disable=unused-argument
+    def test_instrument_connection_enable_commenter(
+        self,
+        mock_connect,
+        mock_instrument_connection,
+    ):
+        cnx = MySQLdb.connect(database="test")
+        cnx = MySQLClientInstrumentor().instrument_connection(
+            cnx,
+            enable_commenter=True,
+            commenter_options={"foo": True},
+        )
+        cursor = cnx.cursor()
+        cursor.execute("SELECT * FROM test")
+        kwargs = mock_instrument_connection.call_args[1]
+        self.assertEqual(kwargs["enable_commenter"], True)
+        self.assertEqual(kwargs["commenter_options"], {"foo": True})
+
+    @mock.patch("opentelemetry.instrumentation.dbapi.wrap_connect")
+    @mock.patch("MySQLdb.connect")
+    # pylint: disable=unused-argument
+    def test__instrument_enable_commenter(
+        self,
+        mock_connect,
+        mock_wrap_connect,
+    ):
+        MySQLClientInstrumentor()._instrument(
+            enable_commenter=True,
+            commenter_options={"foo": True},
+        )
+        kwargs = mock_wrap_connect.call_args[1]
+        self.assertEqual(kwargs["enable_commenter"], True)
+        self.assertEqual(kwargs["commenter_options"], {"foo": True})
+
     @mock.patch("MySQLdb.connect")
     # pylint: disable=unused-argument
     def test_uninstrument_connection(self, mock_connect):


### PR DESCRIPTION
# Description

Updates mysqlclient instrumentor to support sqlcommenting.

Depends on # [2897](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2897)

Fixes # [2902](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2902)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added unit tests. Used local installations of opentelemetry-instrumentation-dbapi (in #[2897](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2897)) and upstream dependencies with this updated downstream instrumentor on a Flask app that use MySQLdb to query MySQL with general logs enabled to check sqlcomments.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [X] Unit tests have been added
- [x] Documentation has been updated
