### PR TITLE
[WIP] Add PyMySQL instrumentor support for sqlcommenting

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
@@ -26,7 +26,6 @@ Usage
     import pymysql
     from opentelemetry.instrumentation.pymysql import PyMySQLInstrumentor
 
-
     PyMySQLInstrumentor().instrument()
 
     cnx = pymysql.connect(database="MySQL_Database")
@@ -40,6 +39,9 @@ SQLCOMMENTER
 *****************************************
 You can optionally configure PyMySQL instrumentation to enable sqlcommenter which enriches
 the query with contextual information.
+
+Usage
+-----
 
 .. code:: python
 
@@ -55,10 +57,13 @@ the query with contextual information.
     cursor.close()
     cnx.close()
 
+
 For example,
 ::
+
    Invoking cursor.execute("INSERT INTO test (testField) VALUES (123)") will lead to sql query "INSERT INTO test (testField) VALUES (123)" but when SQLCommenter is enabled
    the query will get appended with some configurable tags like "INSERT INTO test (testField) VALUES (123) /*tag=value*/;"
+
 
 SQLCommenter Configurations
 ***************************

--- a/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymysql/src/opentelemetry/instrumentation/pymysql/__init__.py
@@ -36,6 +36,70 @@ Usage
     cursor.close()
     cnx.close()
 
+SQLCOMMENTER
+*****************************************
+You can optionally configure PyMySQL instrumentation to enable sqlcommenter which enriches
+the query with contextual information.
+
+.. code:: python
+
+    import MySQLdb
+    from opentelemetry.instrumentation.pymysql import PyMySQLInstrumentor
+
+    PyMySQLInstrumentor().instrument(enable_commenter=True, commenter_options={})
+
+    cnx = MySQLdb.connect(database="MySQL_Database")
+    cursor = cnx.cursor()
+    cursor.execute("INSERT INTO test (testField) VALUES (123)"
+    cnx.commit()
+    cursor.close()
+    cnx.close()
+
+For example,
+::
+   Invoking cursor.execute("INSERT INTO test (testField) VALUES (123)") will lead to sql query "INSERT INTO test (testField) VALUES (123)" but when SQLCommenter is enabled
+   the query will get appended with some configurable tags like "INSERT INTO test (testField) VALUES (123) /*tag=value*/;"
+
+SQLCommenter Configurations
+***************************
+We can configure the tags to be appended to the sqlquery log by adding configuration inside commenter_options(default:{}) keyword
+
+db_driver = True(Default) or False
+
+For example,
+::
+Enabling this flag will add MySQLdb and its version, e.g. /*MySQLdb%%3A1.2.3*/
+
+dbapi_threadsafety = True(Default) or False
+
+For example,
+::
+Enabling this flag will add threadsafety /*dbapi_threadsafety=2*/
+
+dbapi_level = True(Default) or False
+
+For example,
+::
+Enabling this flag will add dbapi_level /*dbapi_level='2.0'*/
+
+mysql_client_version = True(Default) or False
+
+For example,
+::
+Enabling this flag will add mysql_client_version /*mysql_client_version='123'*/
+
+driver_paramstyle = True(Default) or False
+
+For example,
+::
+Enabling this flag will add driver_paramstyle /*driver_paramstyle='pyformat'*/
+
+opentelemetry_values = True(Default) or False
+
+For example,
+::
+Enabling this flag will add traceparent values /*traceparent='00-03afa25236b8cd948fa853d67038ac79-405ff022e8247c46-01'*/
+
 API
 ---
 """
@@ -67,6 +131,8 @@ class PyMySQLInstrumentor(BaseInstrumentor):
         https://github.com/PyMySQL/PyMySQL/
         """
         tracer_provider = kwargs.get("tracer_provider")
+        enable_sqlcommenter = kwargs.get("enable_commenter", False)
+        commenter_options = kwargs.get("commenter_options", {})
 
         dbapi.wrap_connect(
             __name__,
@@ -76,6 +142,8 @@ class PyMySQLInstrumentor(BaseInstrumentor):
             _CONNECTION_ATTRIBUTES,
             version=__version__,
             tracer_provider=tracer_provider,
+            enable_commenter=enable_sqlcommenter,
+            commenter_options=commenter_options,
         )
 
     def _uninstrument(self, **kwargs):
@@ -83,7 +151,12 @@ class PyMySQLInstrumentor(BaseInstrumentor):
         dbapi.unwrap_connect(pymysql, "connect")
 
     @staticmethod
-    def instrument_connection(connection, tracer_provider=None):
+    def instrument_connection(
+        connection,
+        tracer_provider=None,
+        enable_commenter=None,
+        commenter_options=None,
+    ):
         """Enable instrumentation in a PyMySQL connection.
 
         Args:
@@ -102,6 +175,8 @@ class PyMySQLInstrumentor(BaseInstrumentor):
             _CONNECTION_ATTRIBUTES,
             version=__version__,
             tracer_provider=tracer_provider,
+            enable_commenter=enable_commenter,
+            commenter_options=commenter_options,
         )
 
     @staticmethod


### PR DESCRIPTION
# Description

Updates PyMySQL instrumentor to support sqlcommenting.

Depends on # [2897](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2897)

Fixes # [2902](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2902)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added unit tests. Used local installations of opentelemetry-instrumentation-dbapi (in #https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2897) and upstream dependencies with this updated downstream instrumentor on a Flask app that use PyMySQL to query MySQL with general logs enabled to check sqlcomments.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [X] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [X] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
